### PR TITLE
Add support for FreeBSD platform

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class csync2 (
   $inotify_package = $::csync2::params::inotify_package,
   $csync2_exec     = $::csync2::params::csync2_exec,
   $csync2_config   = $::csync2::params::configfile,
+  $xinetd_group    = $::csync2::params::xinetd_group,
 ) inherits ::csync2::params {
 
   #Validate variables
@@ -29,7 +30,7 @@ class csync2 (
   xinetd::service { 'csync2':
     ensure      => $ensure,
     user        => 'root',
-    group       => 'root',
+    group       => "$xinetd_group",
     port        => '30865',
     server      => $csync2_exec,
     server_args => '-i',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class csync2::params {
       $csync2_exec     = '/usr/sbin/csync2'
       $csync2_package  = 'csync2'
       $inotify_package = 'inotify-tools'
+      $xinetd_group    = 'root'
     }
     'Debian': {
       $configpath      = '/etc'
@@ -24,6 +25,15 @@ class csync2::params {
       $csync2_exec     = '/usr/sbin/csync2'
       $csync2_package  = 'csync2'
       $inotify_package = 'inotify-tools'
+      $xinetd_group    = 'root'
+    }
+    'FreeBSD': {
+      $configpath      = '/usr/local/etc'
+      $configfile      = '/usr/local/etc/csync2.cfg'
+      $csync2_exec     = '/usr/local/sbin/csync2'
+      $csync2_package  = 'net/csync2'
+      $inotify_package = 'sysutils/inotify-tools'
+      $xinetd_group    = 'wheel'
     }
     default: {
       fail("Class['csync2::params']: Unsupported OS: ${::osfamily}")

--- a/templates/csync2_body.erb
+++ b/templates/csync2_body.erb
@@ -1,11 +1,11 @@
 
   key <%= @configpath %>/<%= @group_key %>;
-	
+
 <% Array(@includes).sort.each do |incval| -%>
   include <%= incval %>;
 <% end -%>
 
-<% if excludes -%>
+<% if @excludes -%>
 <% Array(@excludes).sort.each do |excval| -%>
   exclude <%= excval %>;
 <% end -%>


### PR DESCRIPTION
- also fixes for error:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Failed to parse template csync2/csync2_body.erb:
  Filepath: /usr/local/etc/puppet/environments/production/modules/public/csync2/templates/csync2_body.erb
  Line: 8
  Detail: undefined local variable or method `excludes' for #<Puppet::Parser::TemplateWrapper:0x00000805b9de50>
```

On Puppet 4.6.2+
