### PR TITLE
Add RHEL 7 support and make inotify optional

### DIFF
--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -105,7 +105,7 @@ define csync2::group (
     path        => ['/sbin','/bin','/usr/bin','/usr/sbin'],
     timeout     => 300,
     refreshonly => true,
-    returns     => ['0','2'],
+    returns     => ['0', '1', '2'],
     require     => Concat[$configfile],
     notify      => Exec['csync2_sync_nodes'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,13 +6,14 @@
 #
 class csync2 (
   $ensure              = 'present',
-  $csync2_rhel_version = '2.0',
   $enable_inotify      = true,
   $checkfreq           = $::csync2::params::checkfreq,
   $csync2_package      = $::csync2::params::csync2_package,
   $inotify_package     = $::csync2::params::inotify_package,
   $csync2_exec         = $::csync2::params::csync2_exec,
   $csync2_config       = $::csync2::params::configfile,
+  $csync2_rhel_version = $::csync2::params::csync2_rhel_version,
+  $csync2_source_url   = $::csync2::params::csync2_source_url,
 ) inherits ::csync2::params {
 
   #Validate variables
@@ -34,7 +35,7 @@ class csync2 (
       ensure        => present,
       extract       => true,
       extract_path  => '/usr/local/src',
-      source        => "http://oss.linbit.com/csync2/csync2-$csync2_rhel_version.tar.gz",
+      source        => "$csync2_source_url",
       creates       => "/usr/local/src/csync2-$csync2_rhel_version",
       cleanup       => false,
     }->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,12 +5,14 @@
 #[checkfreq] The default check frequency for all groups on the csync2 hosts
 #
 class csync2 (
-  $ensure          = 'present',
-  $checkfreq       = $::csync2::params::checkfreq,
-  $csync2_package  = $::csync2::params::csync2_package,
-  $inotify_package = $::csync2::params::inotify_package,
-  $csync2_exec     = $::csync2::params::csync2_exec,
-  $csync2_config   = $::csync2::params::configfile,
+  $ensure              = 'present',
+  $csync2_rhel_version = '2.0',
+  $enable_inotify      = true,
+  $checkfreq           = $::csync2::params::checkfreq,
+  $csync2_package      = $::csync2::params::csync2_package,
+  $inotify_package     = $::csync2::params::inotify_package,
+  $csync2_exec         = $::csync2::params::csync2_exec,
+  $csync2_config       = $::csync2::params::configfile,
 ) inherits ::csync2::params {
 
   #Validate variables
@@ -21,20 +23,43 @@ class csync2 (
   validate_absolute_path($csync2_config)
 
   #Install the basic packages
-  ensure_packages( [$csync2_package, $inotify_package],
-    { ensure => $ensure }
-  )
-
+  if $facts['osfamily'] == "RedHat" and $facts['operatingsystemrelease'] > "6" {
+    ["$inotify_package", "gcc", "librsync", "librsync-devel", "sqlite-devel", "gnutls-devel"].each | $index, $name | {
+      package { $name:
+        ensure => $ensure,
+        before => Archive["/usr/local/src/csync2-$csync2_rhel_version.tar.gz"],
+      }
+    }
+    archive { "/usr/local/src/csync2-$csync2_rhel_version.tar.gz":
+      ensure        => present,
+      extract       => true,
+      extract_path  => '/usr/local/src',
+      source        => "http://oss.linbit.com/csync2/csync2-$csync2_rhel_version.tar.gz",
+      creates       => "/usr/local/src/csync2-$csync2_rhel_version",
+      cleanup       => false,
+    }->
+    exec { "Build and install csync2 on RHEL":
+      command => "cd /usr/local/src/csync2-$csync2_rhel_version && ./configure && make && make install && mkdir $configpath && ln -s /usr/local/sbin/csync2 /usr/sbin/ && ln -s /usr/local/etc/csync2.cfg $configpath",
+      unless  => "test -e /usr/sbin/csync2",
+      path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+    }
+  } else {
+    ensure_packages( [$csync2_package, $inotify_package],
+      { ensure => $ensure }
+    )
+  }
+  
   #Csync2 needs xinetd
   xinetd::service { 'csync2':
-    ensure      => $ensure,
-    user        => 'root',
-    group       => 'root',
-    port        => '30865',
-    server      => $csync2_exec,
-    server_args => '-i',
-    flags       => 'REUSE',
-    protocol    => 'tcp',
+    ensure        => $ensure,
+    user          => 'root',
+    group         => 'root',
+    port          => '30865',
+    server        => $csync2_exec,
+    server_args   => '-i',
+    flags         => 'REUSE',
+    protocol      => 'tcp',
+    service_type  => 'UNLISTED',
   }
 
 }

--- a/manifests/inotify.pp
+++ b/manifests/inotify.pp
@@ -9,39 +9,40 @@ class csync2::inotify (
 ) {
   include ::csync2
 
-  #Validate variables
-  validate_re($ensure, '^present$|^absent$')
-  validate_array($syncfolders)
-  validate_string($sleeptime)
+  if $enable_inotify {
+    #Validate variables
+    validate_re($ensure, '^present$|^absent$')
+    validate_array($syncfolders)
+    validate_string($sleeptime)
 
-  #The inotify script
-  file { '/usr/local/bin/csync2-inotify':
-    ensure  => $ensure,
-    mode    => '0654',
-    owner   => '0',
-    group   => '0',
-    content => template('csync2/inotify_body.erb'),
+    #The inotify script
+    file { '/usr/local/bin/csync2-inotify':
+      ensure  => $ensure,
+      mode    => '0654',
+      owner   => '0',
+      group   => '0',
+      content => template('csync2/inotify_body.erb'),
+    }
+
+    #Basic upstart init script for inotify
+    file { '/etc/init/csync2.conf':
+      ensure  => $ensure,
+      source  => 'puppet:///modules/csync2/csync2.conf',
+      require => File['/usr/local/bin/csync2-inotify'],
+    }
+
+    #Selector for turning 'present' to true
+    $service_ensure = $ensure ? {
+      'present' => true,
+      default   => false,
+    }
+
+    #Start the csync2 service
+    service { 'csync2':
+      ensure  => $service_ensure,
+      enable  => $service_ensure,
+      require => File['/etc/init/csync2.conf'],
+    }
   }
-
-  #Basic upstart init script for inotify
-  file { '/etc/init/csync2.conf':
-    ensure  => $ensure,
-    source  => 'puppet:///modules/csync2/csync2.conf',
-    require => File['/usr/local/bin/csync2-inotify'],
-  }
-
-  #Selector for turning 'present' to true
-  $service_ensure = $ensure ? {
-    'present' => true,
-    default   => false,
-  }
-
-  #Start the csync2 service
-  service { 'csync2':
-    ensure  => $service_ensure,
-    enable  => $service_ensure,
-    require => File['/etc/init/csync2.conf'],
-  }
-
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,15 +8,23 @@ class csync2::params {
   $default_includes = ['/var/tmp']
   $default_excludes = undef
   $default_auto     = 'none'
+  $default_action   = undef
   $default_key      = 'puppet:///modules/csync2/keys/default.key'
 
   case $::osfamily {
     'RedHat': {
-      $configpath      = '/etc/csync2'
-      $configfile      = '/etc/csync2/csync2.cfg'
+      if $facts['operatingsystemrelease'] > "6" {
+        $configfile      = '/usr/local/etc/csync2.cfg'
+      }else {
+        $configfile      = '/etc/csync2/csync2.cfg'
+
+      }
+
       $csync2_exec     = '/usr/sbin/csync2'
       $csync2_package  = 'csync2'
       $inotify_package = 'inotify-tools'
+      $configpath      = '/etc/csync2'
+
     }
     'Debian': {
       $configpath      = '/etc'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,9 @@ class csync2::params {
   case $::osfamily {
     'RedHat': {
       if $facts['operatingsystemrelease'] > "6" {
-        $configfile      = '/usr/local/etc/csync2.cfg'
+        $csync2_source_url    = 'http://oss.linbit.com/csync2/csync2-2.0.tar.gz'
+        $csync2_rhel_version  = '2.0'
+        $configfile           = '/usr/local/etc/csync2.cfg'
       }else {
         $configfile      = '/etc/csync2/csync2.cfg'
 

--- a/metadata.json
+++ b/metadata.json
@@ -55,6 +55,7 @@
   "dependencies": [
     {"name":"puppetlabs/xinetd","version_requirement":">= 1.3.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.0.0"},
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0"},
+    {"name":"puppet/archive","version_requirement":">= 3.0.0"}
   ]
 }

--- a/templates/csync2_body.erb
+++ b/templates/csync2_body.erb
@@ -5,7 +5,7 @@
   include <%= incval %>;
 <% end -%>
 
-<% if excludes -%>
+<% if @excludes -%>
 <% Array(@excludes).sort.each do |excval| -%>
   exclude <%= excval %>;
 <% end -%>
@@ -13,6 +13,12 @@
 
   #Setting for automatic file dispute resolution
   auto <%= @auto %>;
+
+<% if @action -%>
+  action {
+    <%= @action -%>
+  }
+<% end -%>
 
 }
 


### PR DESCRIPTION
This PR will support RHEL7.
Inotify can be used via switch (At this time inotify doesn`t work cause there is no /etc/init folder).
You can define action for your group.
csync2 init can fail if other node/s is not available. 